### PR TITLE
Fix: Kafka 공연정보 Consumer 기능 추가 #17 #18

### DIFF
--- a/src/main/java/com/T82/review/domain/entity/EventInfo.java
+++ b/src/main/java/com/T82/review/domain/entity/EventInfo.java
@@ -27,4 +27,8 @@ public class EventInfo {
     @OneToMany(mappedBy = "eventInfo", cascade = CascadeType.ALL, orphanRemoval = true)
 //    @JsonManagedReference
     private List<Review> review;
+
+    public void deleteEvent() {
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/T82/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/T82/review/domain/repository/ReviewRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Review findByUserAndEventInfo(User user, EventInfo eventInfo);
-    List<Review> findAllByUser(User user);
+//    List<Review> findAllByUser(User user);
     List<Review> findAllByUserAndIsDeleted(User user, Boolean isDeleted);
 }

--- a/src/main/java/com/T82/review/kafka/dto/request/KafkaEventCreateRequest.java
+++ b/src/main/java/com/T82/review/kafka/dto/request/KafkaEventCreateRequest.java
@@ -1,0 +1,15 @@
+package com.T82.review.kafka.dto.request;
+
+import com.T82.review.domain.entity.EventInfo;
+import com.T82.review.domain.entity.User;
+
+public record KafkaEventCreateRequest(
+        Long eventInfoId
+) {
+    public EventInfo toEntity(KafkaEventCreateRequest kafkaEventCreateRequest) {
+        return EventInfo.builder()
+                .eventInfoId(kafkaEventCreateRequest.eventInfoId())
+                .isDeleted(false)
+                .build();
+    }
+}

--- a/src/main/java/com/T82/review/kafka/dto/request/KafkaEventDeleteRequest.java
+++ b/src/main/java/com/T82/review/kafka/dto/request/KafkaEventDeleteRequest.java
@@ -1,0 +1,6 @@
+package com.T82.review.kafka.dto.request;
+
+public record KafkaEventDeleteRequest(
+        Long eventInfoId
+) {
+}

--- a/src/main/java/com/T82/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/T82/review/service/ReviewServiceImpl.java
@@ -14,8 +14,7 @@ import com.T82.review.exception.NoReviewException;
 import com.T82.review.exception.UserDeleteException;
 import com.T82.review.global.utils.TokenInfo;
 import com.T82.review.kafka.dto.KafkaStatus;
-import com.T82.review.kafka.dto.request.KafkaUserDeleteRequest;
-import com.T82.review.kafka.dto.request.KafkaUserSignUpRequest;
+import com.T82.review.kafka.dto.request.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
@@ -102,7 +101,7 @@ public class ReviewServiceImpl implements ReviewService{
 
     @Transactional
     @KafkaListener(topics = "signup-topic")
-    public void synchronizationSignUp(KafkaStatus<KafkaUserSignUpRequest> status){
+    public void synchronizationSignUpUser(KafkaStatus<KafkaUserSignUpRequest> status){
         System.out.println(status.data());
         KafkaUserSignUpRequest data = status.data();
         System.out.println(data.userId());
@@ -113,9 +112,30 @@ public class ReviewServiceImpl implements ReviewService{
 
     @Transactional
     @KafkaListener(topics = "delete-topic")
-    public void synchronizationDelete(KafkaStatus<KafkaUserDeleteRequest> status){
+    public void synchronizationDeleteUser(KafkaStatus<KafkaUserDeleteRequest> status){
         User user = userRepository.findByUserId(status.data().userId());
         user.deleteUser();
         userRepository.save(user);
     }
+
+    //추후 희석이형 보내신 토픽 맞춰 변경 필요
+    @Transactional
+    @KafkaListener(topics = "create-event-topic")
+    public void synchronizationCreateEvent(KafkaStatus<KafkaEventCreateRequest> status){
+        eventInfoRepository.save(status.data().toEntity(status.data()));
+    }
+
+
+    //추후 희석이형 보내신 토픽 맞춰 변경 필요
+    @Transactional
+    @KafkaListener(topics = "delete-event-topic")
+    public void synchronizationDeleteEvent(KafkaStatus<KafkaEventDeleteRequest> status){
+        EventInfo eventInfo = eventInfoRepository.findByEventInfoId(status.data().eventInfoId());
+        eventInfo.deleteEvent();
+        eventInfoRepository.save(eventInfo);
+    }
+
+
+
+
 }


### PR DESCRIPTION
공연정보 서버에서 kafka로 공연정보 생성 및 삭제시, Consumer로 받아 동기화하는 로직입니다.